### PR TITLE
Add graceful hardware failure handling and improve test coverage

### DIFF
--- a/src/motor_python/__main__.py
+++ b/src/motor_python/__main__.py
@@ -27,25 +27,20 @@ def main(
         motor = CubeMarsAK606v3()
     except Exception as e:
         logger.error(f"Failed to initialize motor controller: {e}")
-        logger.info("Exiting gracefully - hardware not available")
+        logger.info("Hardware not available")
         return
 
     with motor:
-        if not motor.connected:
-            logger.warning("Motor hardware not connected - cannot run motor test")
-            logger.info("Exiting gracefully - hardware not available")
+        if not motor.connected or not motor.check_communication():
+            if not motor.connected:
+                logger.warning("Motor hardware not connected - cannot run motor test")
+            else:
+                logger.warning(
+                    "Motor is connected but not responding - hardware may be powered off or cables disconnected"
+                )
             return
 
         logger.info("Testing motor feedback response...")
-
-        # Verify motor is communicating
-        logger.info("Verifying motor communication...")
-        if not motor.check_communication():
-            logger.warning(
-                "Motor is connected but not responding - hardware may be powered off or cables disconnected"
-            )
-            logger.info("Exiting gracefully - hardware not communicating")
-            return
 
         # Query motor status at startup
         logger.info("Initial motor status query:")

--- a/src/motor_python/definitions.py
+++ b/src/motor_python/definitions.py
@@ -46,6 +46,8 @@ DEFAULT_LOG_FILENAME = "log_file"
 DEFAULT_MOTOR_PORT = "/dev/ttyTHS1"
 DEFAULT_MOTOR_BAUDRATE = 921600
 DEFAULT_STEP_DELAY = 0.05
+MAX_COMMUNICATION_ATTEMPTS = 2  # Maximum attempts for communication checks
+COMMUNICATION_RETRY_DELAY = 0.2  # Delay between retry attempts (seconds)
 
 # Motor protocol frame bytes
 FRAME_START_BYTE = 0xAA

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,29 @@
 
 import os
 import sys
+from pathlib import Path
+
+import pytest
 
 # Add the src directory to the path so that the quaternion_ekf package can be imported
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(my_path, "../src"))
+
+
+# Test constants
+@pytest.fixture
+def nonexistent_port():
+    """Provide a non-existent port path for testing error handling."""
+    return Path("/dev/nonexistent")
+
+
+@pytest.fixture
+def test_port():
+    """Provide a test port path for mocking."""
+    return Path("/dev/test")
+
+
+@pytest.fixture
+def mock_response():
+    """Provide a mock motor response byte string."""
+    return b"\xaa\x05\x45\x00\x00\x00\x00\xbb"

--- a/tests/cube_mars_motor_test.py
+++ b/tests/cube_mars_motor_test.py
@@ -10,63 +10,63 @@ def test_cubemarsmotor_initialization():
     assert CubeMarsAK606v3 is not None
 
 
-def test_connection_failure_graceful():
+def test_connection_failure_graceful(nonexistent_port):
     """Test that connection failures are handled gracefully."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         # Simulate serial port not available
         mock_serial.side_effect = Exception("Port not available")
 
         # Should not raise exception
-        motor = CubeMarsAK606v3(port="/dev/nonexistent")
+        motor = CubeMarsAK606v3(port=nonexistent_port)
 
         # Should be marked as not connected
         assert motor.connected is False
         assert motor.communicating is False
 
 
-def test_connection_success():
+def test_connection_success(test_port):
     """Test successful connection."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_instance = MagicMock()
         mock_serial.return_value = mock_instance
 
-        motor = CubeMarsAK606v3(port="/dev/test")
+        motor = CubeMarsAK606v3(port=test_port)
 
         # Should be marked as connected
-        assert motor.connected is True
+        assert motor.connected
         assert motor.serial is not None
 
 
-def test_send_message_when_not_connected():
+def test_send_message_when_not_connected(nonexistent_port):
     """Test that sending messages when not connected returns empty bytes."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_serial.side_effect = Exception("Port not available")
-        motor = CubeMarsAK606v3(port="/dev/nonexistent")
+        motor = CubeMarsAK606v3(port=nonexistent_port)
 
         # Should return empty bytes without error
         result = motor._send_message(b"\xaa\x01\x45\xbb")
         assert result == b""
 
 
-def test_check_communication_not_connected():
+def test_check_communication_not_connected(nonexistent_port):
     """Test check_communication when motor is not connected."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_serial.side_effect = Exception("Port not available")
-        motor = CubeMarsAK606v3(port="/dev/nonexistent")
+        motor = CubeMarsAK606v3(port=nonexistent_port)
 
         # Should return False
         result = motor.check_communication()
         assert result is False
 
 
-def test_check_communication_no_response():
+def test_check_communication_no_response(test_port):
     """Test check_communication when motor doesn't respond."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_instance = MagicMock()
         mock_instance.in_waiting = 0  # No response
         mock_serial.return_value = mock_instance
 
-        motor = CubeMarsAK606v3(port="/dev/test")
+        motor = CubeMarsAK606v3(port=test_port)
 
         # Should return False after timeout
         result = motor.check_communication()
@@ -74,20 +74,20 @@ def test_check_communication_no_response():
         assert motor.communicating is False
 
 
-def test_check_communication_with_response():
+def test_check_communication_with_response(test_port, mock_response):
     """Test check_communication when motor responds."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_instance = MagicMock()
         mock_instance.in_waiting = 10  # Has response
-        mock_instance.read.return_value = b"\xaa\x05\x45\x00\x00\x00\x00\xbb"
+        mock_instance.read.return_value = mock_response
         mock_serial.return_value = mock_instance
 
-        motor = CubeMarsAK606v3(port="/dev/test")
+        motor = CubeMarsAK606v3(port=test_port)
 
         # Should return True
         result = motor.check_communication()
-        assert result is True
-        assert motor.communicating is True
+        assert result
+        assert motor.communicating
 
 
 """Test the main program."""


### PR DESCRIPTION
- Remove sudo requirement from 'make app' command
- Add connection failure handling with warning logs instead of exceptions
- Implement communication health check to detect powered-off/disconnected motors
- Track consecutive response failures and warn when motor stops responding
- Exit gracefully when hardware is unavailable or not communicating
- Add comprehensive unit tests for connection and communication handling
- Increase test coverage from 55% to 67%

# Summary

Provide a brief description of the change and the reasoning behind it.

---

# Reviewers

## Required Reviewers
- @username1  
- @username2  

## Optional Reviewers
- @username3  
- @username4  

(Feel free to add/remove as needed.)

---

# What Changed?

Describe the main changes in this PR:
-
-
-

---

# Testing

Describe how you verified functionality:

- [ ] Unit tests added
- [ ] Existing tests pass
- [ ] Manual testing performed

**Steps to reproduce/test:**
1.  
2.  
3.  

---

# Code Quality Checklist

Before requesting review, ensure:
- [ ] I ran **`make format`**
- [ ] I ran **`make test`**
- [ ] All CI checks pass
- [ ] Code follows project style & conventions
- [ ] New functions/classes include docstrings
- [ ] Public APIs are typed (type hints)

---

# Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)

---

# Additional Notes

- Anything else reviewers should know?
- Attach outputs, plots, logs, or GIFs here.
