### PR TITLE
Fix _send_frame to catch invalid responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docker:
 	docker run --rm motor_python-smoke
 
 app:
-	./.venv/bin/python -m motor_python
+	uv run python -m motor_python
 
 tree:
 	uv run python repo_tree.py --update-readme

--- a/src/motor_python/examples.py
+++ b/src/motor_python/examples.py
@@ -74,6 +74,27 @@ def run_current_control(motor: CubeMarsAK606v3) -> None:
     motor.get_status()
 
 
+def run_max_rpm_test(motor: CubeMarsAK606v3, duration_seconds: float = 3.0) -> None:
+    """Spin motor at maximum RPM for a specified duration.
+
+    :param motor: Motor controller instance.
+    :param duration_seconds: Duration to run at maximum RPM (default: 3 seconds).
+    :return: None
+    """
+    max_erpm = 100000  # Maximum ERPM for the motor
+    logger.info(
+        f"Spinning at maximum RPM ({max_erpm} ERPM) for {duration_seconds} seconds..."
+    )
+
+    motor.set_velocity(velocity_erpm=max_erpm)
+    time.sleep(duration_seconds)
+
+    logger.info("Stopping motor...")
+    motor.set_velocity(velocity_erpm=0)  # Stop
+    time.sleep(0.5)  # Allow motor to come to a complete stop
+    motor.get_status()
+
+
 def run_motor_loop(motor: CubeMarsAK606v3) -> None:
     """Run continuous motor control loop cycling through different modes.
 
@@ -88,6 +109,7 @@ def run_motor_loop(motor: CubeMarsAK606v3) -> None:
         ("Velocity control mode", run_velocity_control),
         ("Duty cycle control mode", run_duty_cycle_control),
         ("Current control mode", run_current_control),
+        ("Max RPM test mode", run_max_rpm_test),
     ]
 
     try:

--- a/tests/cube_mars_motor_test.py
+++ b/tests/cube_mars_motor_test.py
@@ -79,7 +79,11 @@ def test_check_communication_with_response(test_port, mock_response):
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_instance = MagicMock()
         mock_instance.in_waiting = 10  # Has response
-        mock_instance.read.return_value = mock_response
+        # Create a proper response: AA | Length | CMD | Payload (4 bytes) | CRC_H | CRC_L | BB
+        # Length = 1(CMD) + 4(Payload) = 5
+        # Total = 1(AA) + 1(Length) + 5(Data) + 2(CRC) + 1(BB) = 10 bytes
+        proper_response = b"\xaa\x05\x45\x00\x00\x00\x00\x12\x34\xbb"
+        mock_instance.read.return_value = proper_response
         mock_serial.return_value = mock_instance
 
         motor = CubeMarsAK606v3(port=test_port)


### PR DESCRIPTION
# Summary

Provide a brief description of the change and the reasoning behind it.
---
Because the exosuit needs to validate the motor connection at initialization stage, and an unpowered motor / other non-motor devices would return invalid responses, the motor module is patched to check for connection state and handle all the invalid cases. 
# Reviewers

## Required Reviewers
- @username1  
- @username2  

## Optional Reviewers
- @username3  
- @username4  

(Feel free to add/remove as needed.)

---

# What Changed?

Describe the main changes in this PR:
-
-
-

---

# Testing

Describe how you verified functionality:

- [ ] Unit tests added
- [ ] Existing tests pass
- [ ] Manual testing performed

**Steps to reproduce/test:**
1.  
2.  
3.  

---

# Code Quality Checklist

Before requesting review, ensure:
- [ ] I ran **`make format`**
- [ ] I ran **`make test`**
- [ ] All CI checks pass
- [ ] Code follows project style & conventions
- [ ] New functions/classes include docstrings
- [ ] Public APIs are typed (type hints)

---

# Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)

---

# Additional Notes

- Anything else reviewers should know?
- Attach outputs, plots, logs, or GIFs here.
