### PR TITLE
Remove high pitch noise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ init:  # ENV SETUP
 
 test:
 	uv run pytest -m "not hardware" --cov=src --cov-report=term-missing --no-cov-on-fail --cov-report=xml --cov-fail-under=70
-	rm .coverage
+	rm -f .coverage
 
 test-hardware:
 	uv run pytest --cov=src --cov-report=term-missing --no-cov-on-fail --cov-report=xml --cov-fail-under=65
-	rm .coverage
+	rm -f .coverage
 
 lint:
 	uv run ruff format src/ tests/

--- a/README.md
+++ b/README.md
@@ -2,104 +2,89 @@
 [![Coverage Status](https://coveralls.io/repos/github/TUM-Aries-Lab/motor-module/badge.svg?branch=main)](https://coveralls.io/github/TUM-Aries-Lab/motor-module?branch=main)
 ![Docker Image CI](https://github.com/TUM-Aries-Lab/motor-module/actions/workflows/ci.yml/badge.svg)
 
+Velocity-only motor control for exosuit tendon systems (CubeMars AK60-6).
 
+Position, current, and duty cycle modes are removed -- they cause oscillations
+when combined with the firmware's high acceleration trap parameters.
 
 ## Install
-To install the library run:
 
 ```bash
 uv install motor_python
 ```
 
-OR
+## Quick Start
 
-```bash
-uv install git+https://github.com/TUM-Aries-Lab/motor_python.git@<specific-tag>  
-```
-
-## Publishing
-It's super easy to publish your own packages on PyPI. To build and publish this package run:
-1. Update the version number in pyproject.toml and imu_module/__init__.py
-2. Commit your changes and add a git tag "<new.version.number>"
-3. Push the tag `git push --tag`
-
-The package can then be found at: https://pypi.org/project/motor_python
-
-## Module Usage
 ```python
-"""Basic docstring for my module."""
-
-from loguru import logger
-
 from motor_python.cube_mars_motor import CubeMarsAK606v3
 
-def main() -> None:
-    """Run a simple demonstration."""
-    motor = CubeMarsAK606v3()
-    motor.get_status()
-    motor.set_position(position_degrees=0.0)
+motor = CubeMarsAK606v3()
 
-if __name__ == "__main__":
-    main()
+# Direct velocity control
+motor.set_velocity(velocity_erpm=10000)   # Pull tendon
+motor.set_velocity(velocity_erpm=-8000)   # Release tendon
+motor.set_velocity(velocity_erpm=0)       # Stop
+
+# Or use the tendon helper
+motor.control_exosuit_tendon(action="pull", velocity_erpm=10000)
+motor.control_exosuit_tendon(action="release", velocity_erpm=8000)
+motor.control_exosuit_tendon(action="stop")
 ```
 
-## Program Usage
+## API
+
+| Method | Description |
+|--------|-------------|
+| `set_velocity(velocity_erpm, allow_low_speed=False)` | Primary control -- set speed in ERPM |
+| `control_exosuit_tendon(action, velocity_erpm)` | Helper for pull / release / stop |
+| `stop()` | Stop the motor (velocity = 0) |
+| `get_status()` | Query all motor parameters |
+| `check_communication()` | Verify motor is responding |
+
+## Velocity Safety
+
+**Minimum safe velocity: 5000 ERPM** (enforced by default).
+
+Below 5000 ERPM the firmware acceleration settings cause current oscillations,
+audible noise, and motor instability.
+
+```python
+motor.set_velocity(velocity_erpm=10000)              # OK
+motor.set_velocity(velocity_erpm=100)                 # Raises ValueError
+motor.set_velocity(velocity_erpm=100, allow_low_speed=True)  # Bypass
+motor.set_velocity(velocity_erpm=0)                   # Stop always allowed
+```
+
+## Run
+
 ```bash
 uv run python -m motor_python
 ```
 
 ## Testing
 
-### Unit Tests (No Hardware Required)
-Run tests with or without hardware:
 ```bash
-make test          # Run unit tests only (no hardware required, using mocks)
-make test-hardware # Run ALL tests with hardware integration (requires motor connected)
+make test            # Unit tests only (no hardware, uses mocks)
+make test-hardware   # All tests (unit + hardware, requires motor connected)
 ```
 
-**Note:** `make test-hardware` runs all tests (unit + hardware integration) with full coverage reporting. Hardware tests are skipped automatically if motor hardware is not available.
+Hardware tests are skipped automatically if the motor is not available.
 
-## Structure
-<!-- TREE-START -->
+## Project Structure
+
 ```
-├── Test Rig CAD files
-│   ├── Foot.3mf
-│   ├── Jetson_Mount.3mf
-│   ├── Leg_with_2_IMU's.3mf
-│   ├── Motor_Case.3mf
-│   ├── Rod_Adapter_Jetson.3mf
-│   ├── Rod_Adapter_Motor.3mf
-│   └── Spool_V2.3mf
-├── docs
-│   ├── AK60-6 Manual.pdf
-│   └── Jetson-Orin-Nano-DevKit.pdf
-├── src
-│   └── motor_python
-│       ├── __init__.py
-│       ├── __main__.py
-│       ├── cube_mars_motor.py
-│       ├── definitions.py
-│       ├── examples.py
-│       ├── motor_status_parser.py
-│       └── utils.py
-├── tests
-│   ├── __init__.py
-│   ├── conftest.py
-│   ├── cube_mars_motor_test.py
-│   ├── hardware_test.py
-│   ├── motor_status_parser_test.py
-│   └── utils_test.py
-├── .dockerignore
-├── .gitignore
-├── .pre-commit-config.yaml
-├── .python-version
-├── CONTRIBUTING.md
-├── Dockerfile
-├── LICENSE
-├── Makefile
-├── README.md
-├── pyproject.toml
-├── repo_tree.py
-└── uv.lock
+src/motor_python/
+    __init__.py
+    __main__.py           # Entry point (make app)
+    cube_mars_motor.py    # Motor controller class
+    definitions.py        # Constants and limits
+    examples.py           # Demo functions
+    motor_status_parser.py
+    utils.py
+tests/
+    conftest.py
+    cube_mars_motor_test.py   # Unit tests (mocked serial)
+    hardware_test.py          # Integration tests (real motor)
+    motor_status_parser_test.py
+    utils_test.py
 ```
-<!-- TREE-END -->

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![Coverage Status](https://coveralls.io/repos/github/TUM-Aries-Lab/motor-module/badge.svg?branch=main)](https://coveralls.io/github/TUM-Aries-Lab/motor-module?branch=main)
 ![Docker Image CI](https://github.com/TUM-Aries-Lab/motor-module/actions/workflows/ci.yml/badge.svg)
 
-Velocity-only motor control for exosuit tendon systems (CubeMars AK60-6).
+Velocity and position motor control for exosuit tendon systems (CubeMars AK60-6).
 
-Position, current, and duty cycle modes are removed -- they cause oscillations
-when combined with the firmware's high acceleration trap parameters.
+Current and duty cycle modes are removed -- they cause oscillations when combined
+with the firmware's high acceleration trap parameters.
 
 ## Install
 
@@ -20,12 +20,20 @@ from motor_python.cube_mars_motor import CubeMarsAK606v3
 
 motor = CubeMarsAK606v3()
 
-# Direct velocity control
+# Velocity control
 motor.set_velocity(velocity_erpm=10000)   # Pull tendon
 motor.set_velocity(velocity_erpm=-8000)   # Release tendon
-motor.set_velocity(velocity_erpm=0)       # Stop
+motor.stop()                              # Stop (releases windings)
 
-# Or use the tendon helper
+# Position control (hip controller calculates target from IMU angle)
+motor.set_position(position_degrees=90.0)   # Go to 90 degrees
+motor.set_position(position_degrees=0.0)    # Return to home
+motor.get_position()                        # Read current position
+
+# Combined: move to position at a given speed
+motor.move_to_position_with_speed(target_degrees=180.0, motor_speed_erpm=6000)
+
+# Tendon helper
 motor.control_exosuit_tendon(action="pull", velocity_erpm=10000)
 motor.control_exosuit_tendon(action="release", velocity_erpm=8000)
 motor.control_exosuit_tendon(action="stop")
@@ -35,9 +43,12 @@ motor.control_exosuit_tendon(action="stop")
 
 | Method | Description |
 |--------|-------------|
-| `set_velocity(velocity_erpm, allow_low_speed=False)` | Primary control -- set speed in ERPM |
+| `set_velocity(velocity_erpm, allow_low_speed=False)` | Set speed in ERPM |
+| `set_position(position_degrees)` | Set target position in degrees (+/-360) |
+| `get_position()` | Read current position from motor |
+| `move_to_position_with_speed(target_degrees, motor_speed_erpm)` | Move to position via velocity then hold |
 | `control_exosuit_tendon(action, velocity_erpm)` | Helper for pull / release / stop |
-| `stop()` | Stop the motor (velocity = 0) |
+| `stop()` | Stop the motor (current = 0, releases windings) |
 | `get_status()` | Query all motor parameters |
 | `check_communication()` | Verify motor is responding |
 
@@ -54,6 +65,12 @@ motor.set_velocity(velocity_erpm=100)                 # Raises ValueError
 motor.set_velocity(velocity_erpm=100, allow_low_speed=True)  # Bypass
 motor.set_velocity(velocity_erpm=0)                   # Stop always allowed
 ```
+
+## Position Limits
+
+**Range: -360.0 to 360.0 degrees** (one full rotation each direction).
+
+Values outside this range are clamped with a warning.
 
 ## Run
 

--- a/src/motor_python/__init__.py
+++ b/src/motor_python/__init__.py
@@ -1,3 +1,3 @@
-"""Sample doc string."""
+"""Motor control module for CubeMars AK60-6 exosuit actuators."""
 
 __version__ = "0.0.6"

--- a/src/motor_python/__main__.py
+++ b/src/motor_python/__main__.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from motor_python.cube_mars_motor import CubeMarsAK606v3
 from motor_python.definitions import DEFAULT_LOG_LEVEL, LogLevel
-from motor_python.examples import run_motor_loop
+from motor_python.examples import run_motor_demo
 from motor_python.utils import setup_logger
 
 
@@ -46,20 +46,13 @@ def main(
         motor.get_status()
         time.sleep(0.5)
 
-        # Run the motor control loop with all modes
+        # Run the motor demo
         try:
-            run_motor_loop(motor)
+            run_motor_demo(motor)
         except KeyboardInterrupt:
             logger.info("Interrupted by user")
 
-        # Stop motor safely
-        logger.info("Stopping motor...")
-        motor.stop()
-
-        # Final status
-        logger.info("Final motor status:")
-        motor.get_status()
-        time.sleep(0.5)
+        # Motor will be stopped and closed by context manager exit
 
     logger.info("Motor control loop complete!")
 

--- a/src/motor_python/definitions.py
+++ b/src/motor_python/definitions.py
@@ -106,13 +106,8 @@ class ScaleFactors:
     )
     current: float = 100.0  # Current is sent as int32 * 100 (centi-amps)
     duty: float = 1000.0  # Duty cycle is sent as int16 * 1000 (per-mille)
-    duty_command: float = 100000.0  # Duty cycle command is sent as int32 * 100000
-    current_command: float = 1000.0  # Current command is sent as int32 * 1000
     voltage: float = 10.0  # Voltage is sent as int16 * 10 (deci-volts)
     vd_vq: float = 1000.0  # Vd/Vq voltages are sent as int32 * 1000
-    position: float = (
-        1_000_000.0  # Position is sent as int32 * 1,000,000 (micro-degrees)
-    )
 
 
 @dataclass(frozen=True)
@@ -131,17 +126,15 @@ class PayloadSizes:
 
 @dataclass(frozen=True)
 class MotorLimits:
-    """Motor control limits."""
+    """Motor velocity control limits.
 
-    max_duty_cycle: float = 0.95  # Maximum duty cycle (95% to prevent saturation)
-    min_duty_cycle: float = -0.95  # Minimum duty cycle
-    max_current_amps: float = 60.0  # Maximum current in amps
-    min_current_amps: float = -60.0  # Minimum current in amps
-    max_velocity_electrical_rpm: int = 100000  # Maximum velocity in Electrical RPM
-    min_velocity_electrical_rpm: int = -100000  # Minimum velocity in Electrical RPM
-    max_position_degrees: float = 2147.483647  # Maximum position based on int32 limit
-    min_position_degrees: float = -2147.483648  # Minimum position based on int32 limit
-    max_movement_time: float = 5.0  # Maximum movement time cap in seconds
+    Only velocity control is supported. Low speeds (< 5000 ERPM) with high
+    firmware acceleration settings cause current oscillations and noise.
+    """
+
+    max_velocity_electrical_rpm: int = 100000
+    min_velocity_electrical_rpm: int = -100000
+    min_safe_velocity_erpm: int = 5000  # Below this, firmware accel causes oscillations
 
 
 @dataclass(frozen=True)

--- a/src/motor_python/definitions.py
+++ b/src/motor_python/definitions.py
@@ -67,6 +67,8 @@ class FrameBytes:
     end: int = 0xBB
     min_response_length: int = 10  # Minimum valid response frame length
     min_frame_with_payload: int = 6  # Minimum frame length that includes payload
+    expected_status_response_length: int = 90  # Full status response (cmd 0x45)
+    min_status_response_length: int = 85  # Minimum acceptable status response
     separator_length: int = 50  # Length of separator line in logs
     start_index: int = 0  # Index of start byte in frame
     length_index: int = 1  # Index of length byte in frame
@@ -142,6 +144,8 @@ class MotorLimits:
     max_movement_time: float = 5.0  # Maximum movement time cap in seconds
     soft_start_current_ma: int = 3000  # Gentle current (mA) to pre-spin past noisy zone
     soft_start_duration: float = 0.15  # Seconds to hold pre-spin current
+    default_tendon_velocity_erpm: int = 10000  # Default velocity for tendon control
+    default_velocity_demo_erpm: int = 8000  # Safe moderate velocity for demo/testing
 
 
 @dataclass(frozen=True)
@@ -162,6 +166,15 @@ SCALE_FACTORS = ScaleFactors()
 PAYLOAD_SIZES = PayloadSizes()
 MOTOR_LIMITS = MotorLimits()
 CONVERSION_FACTORS = ConversionFactors()
+
+
+# Tendon action control
+class TendonAction(IntEnum):
+    """Exosuit tendon control actions."""
+
+    PULL = 0  # Pull tendon (lift/assist)
+    RELEASE = 1  # Release tendon (lower/relax)
+    STOP = 2  # Stop motion
 
 
 # Motor Fault Codes (from CubeMars Manual)

--- a/src/motor_python/definitions.py
+++ b/src/motor_python/definitions.py
@@ -20,8 +20,6 @@ ENCODING: str = "utf-8"
 
 DATE_FORMAT = "%Y-%m-%d_%H-%M-%S"
 
-DUMMY_VARIABLE = "dummy_variable"
-
 
 @dataclass
 class LogLevel:
@@ -108,6 +106,9 @@ class ScaleFactors:
     duty: float = 1000.0  # Duty cycle is sent as int16 * 1000 (per-mille)
     voltage: float = 10.0  # Voltage is sent as int16 * 10 (deci-volts)
     vd_vq: float = 1000.0  # Vd/Vq voltages are sent as int32 * 1000
+    position: float = (
+        1_000_000.0  # Position is sent as int32 * 1,000,000 (micro-degrees)
+    )
 
 
 @dataclass(frozen=True)
@@ -126,15 +127,21 @@ class PayloadSizes:
 
 @dataclass(frozen=True)
 class MotorLimits:
-    """Motor velocity control limits.
+    """Motor velocity and position control limits.
 
-    Only velocity control is supported. Low speeds (< 5000 ERPM) with high
-    firmware acceleration settings cause current oscillations and noise.
+    Low speeds (< 5000 ERPM) with high firmware acceleration settings cause
+    current oscillations and noise. Position is limited to +/-360 degrees
+    (one full rotation each direction) for exosuit joint safety.
     """
 
     max_velocity_electrical_rpm: int = 100000
     min_velocity_electrical_rpm: int = -100000
     min_safe_velocity_erpm: int = 5000  # Below this, firmware accel causes oscillations
+    max_position_degrees: float = 360.0  # Maximum position: 1 full rotation
+    min_position_degrees: float = -360.0  # Minimum position: -1 full rotation
+    max_movement_time: float = 5.0  # Maximum movement time cap in seconds
+    soft_start_current_ma: int = 3000  # Gentle current (mA) to pre-spin past noisy zone
+    soft_start_duration: float = 0.15  # Seconds to hold pre-spin current
 
 
 @dataclass(frozen=True)

--- a/src/motor_python/examples.py
+++ b/src/motor_python/examples.py
@@ -25,8 +25,41 @@ def run_velocity_control(motor: CubeMarsAK606v3, velocity_erpm: int = 8000) -> N
     motor.get_status()
 
     logger.info("Stop...")
-    motor.set_velocity(velocity_erpm=0)
+    motor.stop()
     motor.get_status()
+
+
+def run_position_control(motor: CubeMarsAK606v3) -> None:
+    """Run position control demo.
+
+    Demonstrates set_position, get_position, and move_to_position_with_speed.
+
+    :param motor: Motor controller instance
+    :return: None
+    """
+    logger.info("Position control: move to 90 degrees...")
+    motor.set_position(position_degrees=90.0)
+    time.sleep(1.0)
+    motor.get_position()
+    motor.stop()
+
+    logger.info("Position control: move to -90 degrees...")
+    motor.set_position(position_degrees=-90.0)
+    time.sleep(1.0)
+    motor.get_position()
+    motor.stop()
+
+    logger.info("Position control: move to 180 degrees at 6000 ERPM...")
+    motor.move_to_position_with_speed(target_degrees=180.0, motor_speed_erpm=6000)
+    time.sleep(0.5)
+    motor.get_position()
+    motor.stop()
+
+    logger.info("Position control: return to home (0 degrees)...")
+    motor.set_position(position_degrees=0.0)
+    time.sleep(1.0)
+    motor.get_status()
+    motor.stop()
 
 
 def run_max_rpm_test(motor: CubeMarsAK606v3, duration_seconds: float = 3.0) -> None:
@@ -43,7 +76,7 @@ def run_max_rpm_test(motor: CubeMarsAK606v3, duration_seconds: float = 3.0) -> N
     time.sleep(duration_seconds)
 
     logger.info("Stopping motor...")
-    motor.set_velocity(velocity_erpm=0)
+    motor.stop()
     time.sleep(0.5)
     motor.get_status()
 
@@ -90,7 +123,15 @@ def run_motor_demo(motor: CubeMarsAK606v3) -> None:
         motor.stop()
         time.sleep(2.0)
 
-        # Demo 2: Exosuit tendon control
+        # Demo 2: Position control
+        logger.info("\n" + "=" * 60)
+        logger.info(">>> RUNNING: run_position_control()")
+        logger.info("=" * 60)
+        run_position_control(motor)
+        motor.stop()
+        time.sleep(2.0)
+
+        # Demo 3: Exosuit tendon control
         logger.info("\n" + "=" * 60)
         logger.info(">>> RUNNING: run_exosuit_tendon_control()")
         logger.info("=" * 60)
@@ -98,7 +139,7 @@ def run_motor_demo(motor: CubeMarsAK606v3) -> None:
         motor.stop()
         time.sleep(2.0)
 
-        # Demo 3: Max RPM test
+        # Demo 4: Max RPM test
         logger.info("\n" + "=" * 60)
         logger.info(">>> RUNNING: run_max_rpm_test(2s)")
         logger.info("=" * 60)

--- a/src/motor_python/examples.py
+++ b/src/motor_python/examples.py
@@ -5,9 +5,12 @@ import time
 from loguru import logger
 
 from motor_python.cube_mars_motor import CubeMarsAK606v3
+from motor_python.definitions import MOTOR_LIMITS, TendonAction
 
 
-def run_velocity_control(motor: CubeMarsAK606v3, velocity_erpm: int = 8000) -> None:
+def run_velocity_control(
+    motor: CubeMarsAK606v3, velocity_erpm: int = MOTOR_LIMITS.default_velocity_demo_erpm
+) -> None:
     """Run velocity control with forward and reverse.
 
     :param motor: Motor controller instance
@@ -69,7 +72,7 @@ def run_max_rpm_test(motor: CubeMarsAK606v3, duration_seconds: float = 3.0) -> N
     :param duration_seconds: Duration to run at max RPM (default: 3s)
     :return: None
     """
-    max_erpm = 100000
+    max_erpm = MOTOR_LIMITS.max_velocity_electrical_rpm
     logger.info(f"Spinning at max RPM ({max_erpm} ERPM) for {duration_seconds}s...")
 
     motor.set_velocity(velocity_erpm=max_erpm)
@@ -92,15 +95,15 @@ def run_exosuit_tendon_control(motor: CubeMarsAK606v3) -> None:
     logger.info("Exosuit tendon control demo...")
 
     logger.info("Pull tendon (lift)")
-    motor.control_exosuit_tendon(action="pull", velocity_erpm=12000)
+    motor.control_exosuit_tendon(action=TendonAction.PULL, velocity_erpm=12000)
     time.sleep(0.8)
 
     logger.info("Release tendon (lower)")
-    motor.control_exosuit_tendon(action="release", velocity_erpm=8000)
+    motor.control_exosuit_tendon(action=TendonAction.RELEASE, velocity_erpm=8000)
     time.sleep(0.8)
 
     logger.info("Stop")
-    motor.control_exosuit_tendon(action="stop")
+    motor.control_exosuit_tendon(action=TendonAction.STOP)
     time.sleep(0.3)
     motor.get_status()
 
@@ -117,9 +120,13 @@ def run_motor_demo(motor: CubeMarsAK606v3) -> None:
     try:
         # Demo 1: Basic velocity control
         logger.info("\n" + "=" * 60)
-        logger.info(">>> RUNNING: run_velocity_control(8000 ERPM)")
+        logger.info(
+            f">>> RUNNING: run_velocity_control({MOTOR_LIMITS.default_velocity_demo_erpm} ERPM)"
+        )
         logger.info("=" * 60)
-        run_velocity_control(motor, velocity_erpm=8000)
+        run_velocity_control(
+            motor, velocity_erpm=MOTOR_LIMITS.default_velocity_demo_erpm
+        )
         motor.stop()
         time.sleep(2.0)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-# Add the src directory to the path so that the quaternion_ekf package can be imported
+# Add the src directory to the path so that the motor_python package can be imported
 my_path = Path(__file__).parent
 sys.path.insert(0, str(my_path / "../src"))
 

--- a/tests/cube_mars_motor_test.py
+++ b/tests/cube_mars_motor_test.py
@@ -1,97 +1,149 @@
-"""Test the CubeMars motor module."""
+"""Unit tests for CubeMars motor module (no hardware required)."""
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from motor_python.cube_mars_motor import CubeMarsAK606v3
+
+# -- Initialization --
 
 
 def test_cubemarsmotor_initialization():
-    """Test that CubeMarsAK606v3 class can be imported."""
+    """CubeMarsAK606v3 class can be imported."""
     assert CubeMarsAK606v3 is not None
 
 
 def test_connection_failure_graceful(nonexistent_port):
-    """Test that connection failures are handled gracefully."""
+    """Connection failures are handled gracefully."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
-        # Simulate serial port not available
         mock_serial.side_effect = Exception("Port not available")
-
-        # Should not raise exception
         motor = CubeMarsAK606v3(port=nonexistent_port)
-
-        # Should be marked as not connected
         assert motor.connected is False
         assert motor.communicating is False
 
 
 def test_connection_success(test_port):
-    """Test successful connection."""
+    """Successful connection marks motor as connected."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
-        mock_instance = MagicMock()
-        mock_serial.return_value = mock_instance
-
+        mock_serial.return_value = MagicMock()
         motor = CubeMarsAK606v3(port=test_port)
-
-        # Should be marked as connected
         assert motor.connected
         assert motor.serial is not None
 
 
+# -- Send / Communication --
+
+
 def test_send_frame_when_not_connected(nonexistent_port):
-    """Test that sending frames when not connected returns empty bytes."""
+    """Sending frames when not connected returns empty bytes."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_serial.side_effect = Exception("Port not available")
         motor = CubeMarsAK606v3(port=nonexistent_port)
-
-        # Should return empty bytes without error
         result = motor._send_frame(b"\xaa\x01\x45\xbb")
         assert result == b""
 
 
 def test_check_communication_not_connected(nonexistent_port):
-    """Test check_communication when motor is not connected."""
+    """check_communication returns False when not connected."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_serial.side_effect = Exception("Port not available")
         motor = CubeMarsAK606v3(port=nonexistent_port)
-
-        # Should return False
-        result = motor.check_communication()
-        assert not result
+        assert not motor.check_communication()
 
 
 def test_check_communication_no_response(test_port):
-    """Test check_communication when motor doesn't respond."""
+    """check_communication returns False when motor doesn't respond."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_instance = MagicMock()
-        mock_instance.in_waiting = 0  # No response
+        mock_instance.in_waiting = 0
         mock_serial.return_value = mock_instance
-
         motor = CubeMarsAK606v3(port=test_port)
-
-        # Should return False after timeout
-        result = motor.check_communication()
-        assert not result
+        assert not motor.check_communication()
         assert not motor.communicating
 
 
 def test_check_communication_with_response(test_port, mock_response):
-    """Test check_communication when motor responds."""
+    """check_communication returns True when motor responds."""
     with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
         mock_instance = MagicMock()
-        mock_instance.in_waiting = 10  # Has response
-        # Create a proper response: AA | Length | CMD | Payload (4 bytes) | CRC_H | CRC_L | BB
-        # Length = 1(CMD) + 4(Payload) = 5
-        # Total = 1(AA) + 1(Length) + 5(Data) + 2(CRC) + 1(BB) = 10 bytes
-        proper_response = b"\xaa\x05\x45\x00\x00\x00\x00\x12\x34\xbb"
-        mock_instance.read.return_value = proper_response
+        mock_instance.in_waiting = 10
+        mock_instance.read.return_value = b"\xaa\x05\x45\x00\x00\x00\x00\x12\x34\xbb"
         mock_serial.return_value = mock_instance
-
         motor = CubeMarsAK606v3(port=test_port)
-
-        # Should return True
-        result = motor.check_communication()
-        assert result
+        assert motor.check_communication()
         assert motor.communicating
 
 
-"""Test the main program."""
+# -- Velocity Safety --
+
+
+def test_low_velocity_blocked(test_port):
+    """Dangerously low velocities are blocked by default."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_serial.return_value = MagicMock()
+        motor = CubeMarsAK606v3(port=test_port)
+        with pytest.raises(ValueError, match="below safe threshold"):
+            motor.set_velocity(velocity_erpm=100)
+
+
+def test_low_velocity_allowed_with_flag(test_port):
+    """Low velocity works with allow_low_speed=True."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.set_velocity(velocity_erpm=100, allow_low_speed=True)
+
+
+def test_zero_velocity_always_allowed(test_port):
+    """Zero velocity (stop) is always allowed."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.set_velocity(velocity_erpm=0)
+
+
+# -- Tendon Control --
+
+
+def test_tendon_pull(test_port):
+    """Tendon pull action sends positive velocity."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.control_exosuit_tendon(action="pull", velocity_erpm=10000)
+
+
+def test_tendon_release(test_port):
+    """Tendon release action sends negative velocity."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.control_exosuit_tendon(action="release", velocity_erpm=10000)
+
+
+def test_tendon_stop(test_port):
+    """Tendon stop action sends zero velocity."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.control_exosuit_tendon(action="stop")
+
+
+def test_tendon_invalid_action(test_port):
+    """Invalid tendon action raises ValueError."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_serial.return_value = MagicMock()
+        motor = CubeMarsAK606v3(port=test_port)
+        with pytest.raises(ValueError, match="Invalid action"):
+            motor.control_exosuit_tendon(action="invalid")

--- a/tests/cube_mars_motor_test.py
+++ b/tests/cube_mars_motor_test.py
@@ -147,3 +147,67 @@ def test_tendon_invalid_action(test_port):
         motor = CubeMarsAK606v3(port=test_port)
         with pytest.raises(ValueError, match="Invalid action"):
             motor.control_exosuit_tendon(action="invalid")
+
+
+# -- Position Control --
+
+
+def test_set_position_within_limits(test_port):
+    """Position within +/-360 degrees is accepted."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.set_position(position_degrees=180.0)
+
+
+def test_set_position_clamped(test_port):
+    """Position exceeding +/-360 degrees is clamped."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.set_position(position_degrees=500.0)  # Clamped to 360
+
+
+def test_set_position_negative(test_port):
+    """Negative position is accepted within limits."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.set_position(position_degrees=-270.0)
+
+
+def test_set_position_zero(test_port):
+    """Zero position (home) is accepted."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.set_position(position_degrees=0.0)
+
+
+def test_get_position_returns_bytes(test_port):
+    """get_position returns bytes from motor."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        result = motor.get_position()
+        assert isinstance(result, bytes)
+
+
+def test_move_to_position_with_speed(test_port):
+    """move_to_position_with_speed sends velocity then position."""
+    with patch("motor_python.cube_mars_motor.serial.Serial") as mock_serial:
+        mock_instance = MagicMock()
+        mock_instance.in_waiting = 0
+        mock_serial.return_value = mock_instance
+        motor = CubeMarsAK606v3(port=test_port)
+        motor.move_to_position_with_speed(target_degrees=90.0, motor_speed_erpm=6000)

--- a/tests/hardware_test.py
+++ b/tests/hardware_test.py
@@ -1,7 +1,6 @@
-"""Hardware integration tests - only run when hardware is available.
+"""Hardware integration tests - velocity control only.
 
-These tests require actual motor hardware connected.
-Run with: make test-hardware
+Requires motor hardware connected. Run with: make test-hardware
 """
 
 import logging
@@ -11,44 +10,28 @@ from collections.abc import Generator
 import pytest
 
 from motor_python.cube_mars_motor import CubeMarsAK606v3
-from motor_python.examples import (
-    run_duty_cycle_control,
-    run_position_control,
-)
 
-# Logger records warning messages when motor fails to stop or reset after tests complete
 logger = logging.getLogger(__name__)
 
-# Mark all tests in this file as hardware tests
 pytestmark = pytest.mark.hardware
 
 
 def get_status_with_retry(
     motor: CubeMarsAK606v3, max_retries: int = 8, delay: float = 0.12
 ) -> bytes:
-    """Get motor status with retry logic for unreliable communication.
+    """Get motor status with retry logic for unreliable UART.
 
-    Args:
-        motor: Motor instance
-        max_retries: Maximum number of retry attempts
-        delay: Delay between retries in seconds
-
-    Returns:
-        Valid status bytes
-
-    Raises:
-        AssertionError: If unable to get valid status after all retries
-
+    :param motor: Motor instance
+    :param max_retries: Maximum retry attempts
+    :param delay: Delay between retries in seconds
+    :return: Valid status bytes (>= 85 bytes)
     """
     for attempt in range(max_retries):
         status = motor.get_status()
-        # Check if we got a valid response with expected structure
-        # Valid status should be 90 bytes (AA 55 command data... checksum BB)
         if status is not None and len(status) >= 85:
             return status
         if attempt < max_retries - 1:
             time.sleep(delay)
-    # Last attempt without delay
     status = motor.get_status()
     assert status is not None and len(status) >= 85, (
         f"Failed to get valid status after retries (got {len(status) if status else 0} bytes)"
@@ -56,335 +39,176 @@ def get_status_with_retry(
     return status
 
 
+def parse_speed_from_status(motor: CubeMarsAK606v3, status: bytes) -> int | None:
+    """Parse speed from a status response, returning None if data looks corrupted.
+
+    :param motor: Motor instance (for its status_parser)
+    :param status: Raw status bytes
+    :return: Speed in ERPM, or None if data is corrupted
+    """
+    motor.status_parser.payload_offset = 0
+    motor.status_parser.parse_temperatures(status)
+    motor.status_parser.parse_currents(status)
+    dsv = motor.status_parser.parse_duty_speed_voltage(status)
+    if dsv is None or abs(dsv.speed_erpm) >= 1_000_000:
+        return None  # Corrupted data
+    return dsv.speed_erpm
+
+
 @pytest.fixture
 def motor() -> Generator[CubeMarsAK606v3, None, None]:
-    """Provide a motor instance with real hardware connection."""
+    """Provide a motor instance; stop and close on teardown."""
     motor = CubeMarsAK606v3()
     if not motor.connected:
         pytest.skip("Motor hardware not available")
     yield motor
     try:
-        # Ensure motor is stopped and returned to zero position for safety
-        try:
-            motor.stop()
-        except Exception as e:
-            logger.warning(f"Failed to stop motor during cleanup: {e}")
-        try:
-            motor.set_position(position_degrees=0.0)
-        except Exception as e:
-            logger.warning(f"Failed to reset motor position during cleanup: {e}")
-        motor.close()
+        motor.stop()
+    except Exception as e:
+        logger.warning(f"Failed to stop motor during cleanup: {e}")
     finally:
         motor.close()
 
 
+# -- Connection --
+
+
 class TestHardwareConnection:
-    """Test actual hardware connection and communication."""
+    """Verify hardware connection and communication."""
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
     def test_motor_connection(self, motor: CubeMarsAK606v3) -> None:
-        """Test that motor connects successfully."""
+        """Motor connects and serial port is open."""
         assert motor.connected
         assert motor.serial is not None
         assert motor.serial.is_open
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
     def test_motor_communication(self, motor: CubeMarsAK606v3) -> None:
-        """Test that motor responds to status queries."""
-        result = motor.check_communication()
-        assert result
+        """Motor responds to status queries."""
+        assert motor.check_communication()
         assert motor.communicating
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
     def test_get_status(self, motor: CubeMarsAK606v3) -> None:
-        """Test getting motor status."""
+        """Status response has expected minimum length."""
         status = get_status_with_retry(motor)
         assert status is not None
-        assert len(status) > 0
+        assert len(status) >= 85
+
+
+# -- Velocity Control --
+
+
+class TestVelocityControl:
+    """Test velocity commands with real hardware."""
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_get_position(self, motor: CubeMarsAK606v3) -> None:
-        """Test getting motor position."""
-        response = motor.get_position()
-        assert response is not None
-
-
-class TestHardwareMotorControl:
-    """Test motor control with actual hardware - verify motor responds to commands."""
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_set_position(self, motor: CubeMarsAK606v3) -> None:
-        """Test setting motor position command works."""
-        # Set to zero position
-        motor.set_position(position_degrees=0.0)
-        time.sleep(0.5)  # Give motor time to move
-
-        # Verify motor reached the position
-        status = get_status_with_retry(motor)
-        assert status is not None
-        assert len(status) > 0
-
-        motor.status_parser.payload_offset = 0
-        motor.status_parser.parse_temperatures(status)
-        motor.status_parser.parse_currents(status)
-        motor.status_parser.parse_duty_speed_voltage(status)
-        status_pos = motor.status_parser.parse_status_position(status)
-        assert status_pos is not None
-        assert abs(status_pos.position_degrees - 0.0) < 2.0
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_position_movement(self, motor: CubeMarsAK606v3) -> None:
-        """Test motor accepts multiple position commands using position control."""
-        # Test specific position and verify it's reached
-        target_position = 20.0
-        motor.set_position(position_degrees=target_position)
-        time.sleep(0.6)  # Give motor time to move
-
-        # Verify motor reached target position within tolerance
-        status = get_status_with_retry(motor)
-        assert status is not None
-        assert len(status) > 0
-
-        motor.status_parser.payload_offset = 0
-        motor.status_parser.parse_temperatures(status)
-        motor.status_parser.parse_currents(status)
-        motor.status_parser.parse_duty_speed_voltage(status)
-        status_pos = motor.status_parser.parse_status_position(status)
-        assert status_pos is not None
-        # Allow ±3° tolerance for position accuracy
-        # Skip verification if data is clearly corrupted (position < 1e-10 or > 10000)
-        if (
-            abs(status_pos.position_degrees) > 1e-10
-            and abs(status_pos.position_degrees) < 10000
-        ):
-            assert abs(status_pos.position_degrees - target_position) < 3.0, (
-                f"Position {status_pos.position_degrees}° not close to target {target_position}°"
-            )
-
-        # Use the position control example function for multiple movements
-        run_position_control(motor, num_steps=10, max_angle_degrees=30.0)
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_set_velocity(self, motor: CubeMarsAK606v3) -> None:
-        """Test setting motor velocity command works using velocity control."""
-        # Set a specific velocity and verify motor reaches it
-        target_velocity = 8000
-        motor.set_velocity(velocity_erpm=target_velocity)
-        time.sleep(0.5)  # Give motor time to reach velocity
-
-        # Verify motor is moving at commanded velocity within tolerance
-        status = get_status_with_retry(motor)
-        assert status is not None
-
-        motor.status_parser.payload_offset = 0
-        motor.status_parser.parse_temperatures(status)
-        motor.status_parser.parse_currents(status)
-        duty_speed_voltage = motor.status_parser.parse_duty_speed_voltage(status)
-        assert duty_speed_voltage is not None
-        # Skip verification if value is obviously corrupted (> 1M indicates byte misalignment)
-        if abs(duty_speed_voltage.speed_erpm) < 1000000:
-            # Allow ±30% tolerance for velocity accuracy
-            velocity_error = abs(duty_speed_voltage.speed_erpm - target_velocity)
-            assert velocity_error < target_velocity * 0.3, (
-                f"Velocity {duty_speed_voltage.speed_erpm} not close to target {target_velocity} ERPM"
-            )
-
-        # Stop motor and verify it stops
-        motor.set_velocity(velocity_erpm=0)
-        time.sleep(0.3)
-        status = get_status_with_retry(motor)
-        assert status is not None
-
-        motor.status_parser.payload_offset = 0
-        motor.status_parser.parse_temperatures(status)
-        motor.status_parser.parse_currents(status)
-        duty_speed_voltage = motor.status_parser.parse_duty_speed_voltage(status)
-        assert duty_speed_voltage is not None
-        # Verify speed is close to 0 after stopping
-        if abs(duty_speed_voltage.speed_erpm) < 1000000:
-            assert abs(duty_speed_voltage.speed_erpm) < 10000, (
-                f"Speed {duty_speed_voltage.speed_erpm} too high - motor should be stopped"
-            )
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_set_duty_cycle(self, motor: CubeMarsAK606v3) -> None:
-        """Test setting duty cycle using duty cycle control."""
-        # Use the duty cycle control example function
-        run_duty_cycle_control(motor)
-
-        # Verify motor is responsive after the sequence
-        status = get_status_with_retry(motor)
-        assert status is not None
-        assert len(status) > 0
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_set_current(self, motor: CubeMarsAK606v3) -> None:
-        """Test setting motor current using current control."""
-        # Set a specific current and verify motor draws it
-        target_current = 2.0  # 2A
-        motor.set_current(current_amps=target_current)
+    def test_set_velocity_and_stop(self, motor: CubeMarsAK606v3) -> None:
+        """Set velocity, verify motor reaches target, then stop."""
+        target = 8000
+        motor.set_velocity(velocity_erpm=target)
         time.sleep(0.5)
 
-        # Verify motor is drawing current (within reasonable range)
-        status = get_status_with_retry(motor)
-        assert status is not None
-        assert len(status) > 0
-
-        motor.status_parser.payload_offset = 0
-        motor.status_parser.parse_temperatures(status)
-        currents = motor.status_parser.parse_currents(status)
-        assert currents is not None
-        # Verify motor is drawing some current (allow wide tolerance for current control)
-        # Current can vary significantly based on load, so just verify it's non-zero
-        # Skip if data is clearly corrupted (> 100A)
-        if abs(currents.output_current_amps) < 100:
-            assert abs(currents.output_current_amps) > 0.1, (
-                f"Motor current {currents.output_current_amps}A is too low"
+        speed = parse_speed_from_status(motor, get_status_with_retry(motor))
+        if speed is not None:
+            assert abs(speed - target) < target * 0.3, (
+                f"Speed {speed} ERPM not within 30% of target {target} ERPM"
             )
 
-        # Stop motor
-        motor.stop()
-        time.sleep(0.2)
+        motor.set_velocity(velocity_erpm=0)
+        time.sleep(0.3)
+
+        speed = parse_speed_from_status(motor, get_status_with_retry(motor))
+        if speed is not None:
+            assert abs(speed) < 10000, f"Motor should be stopped, got {speed} ERPM"
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
     def test_stop(self, motor: CubeMarsAK606v3) -> None:
-        """Test motor stop function."""
+        """motor.stop() brings speed near zero."""
         motor.stop()
         time.sleep(0.2)
 
-        # Verify motor is actually stopped
-        status = get_status_with_retry(motor)
-        assert status is not None
-
-        motor.status_parser.payload_offset = 0
-        motor.status_parser.parse_temperatures(status)
-        motor.status_parser.parse_currents(status)
-        duty_speed_voltage = motor.status_parser.parse_duty_speed_voltage(status)
-        assert duty_speed_voltage is not None
-        # Verify motor speed is close to 0
-        # Skip verification if value is obviously corrupted (> 1M indicates byte misalignment)
-        if abs(duty_speed_voltage.speed_erpm) < 1000000:
-            assert abs(duty_speed_voltage.speed_erpm) < 10000, (
-                f"Speed {duty_speed_voltage.speed_erpm} too high - motor should be stopped"
-            )
-
-
-class TestHardwareEdgeCases:
-    """Test edge cases with real hardware."""
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_position_clamping(self, motor: CubeMarsAK606v3) -> None:
-        """Test that position values are properly clamped."""
-        # Try to set beyond limits
-        motor.set_position(position_degrees=500.0)  # Should be clamped to 360
-        time.sleep(0.2)
-
-        motor.set_position(position_degrees=-500.0)  # Should be clamped to -360
-        time.sleep(0.2)
-
-        # Return to zero
-        motor.set_position(position_degrees=0.0)
-        time.sleep(0.2)
+        speed = parse_speed_from_status(motor, get_status_with_retry(motor))
+        if speed is not None:
+            assert abs(speed) < 10000
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
     def test_velocity_clamping(self, motor: CubeMarsAK606v3) -> None:
-        """Test that velocity values are properly clamped."""
-        # Try to set beyond limits
-        motor.set_velocity(velocity_erpm=150000)  # Should be clamped to 100000
+        """Values beyond +-100000 ERPM are clamped, not rejected."""
+        motor.set_velocity(velocity_erpm=150000)  # Clamped to 100000
         time.sleep(0.2)
-
-        motor.set_velocity(velocity_erpm=0)  # Stop
-        time.sleep(0.1)
+        motor.set_velocity(velocity_erpm=0)
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_consecutive_commands(self, motor: CubeMarsAK606v3) -> None:
-        """Test sending multiple commands in sequence."""
-        motor.set_position(position_degrees=10.0)
-        time.sleep(0.1)
-        motor.set_position(position_degrees=-10.0)
-        time.sleep(0.1)
-        motor.set_position(position_degrees=0.0)
-        time.sleep(0.1)
-
-        status = motor.get_status()
-        assert status is not None
-
-
-class TestMotorMeasurements:
-    """Test that motor measurements can be retrieved."""
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_status_retrieval_consistency(self, motor: CubeMarsAK606v3) -> None:
-        """Test that status can be retrieved consistently."""
-        # Set to known position
-        motor.set_position(position_degrees=0.0)
-        time.sleep(0.5)
-
-        # Read status multiple times - should always succeed with retry
-        for _ in range(5):
-            status = get_status_with_retry(motor)
-            assert status is not None
-            assert len(status) > 0
-            time.sleep(0.1)
-
-    @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    def test_velocity_command_response(self, motor: CubeMarsAK606v3) -> None:
-        """Test that motor responds during velocity commands."""
-        # Set velocity and check motor is actually moving
+    def test_motor_spinning(self, motor: CubeMarsAK606v3) -> None:
+        """Motor reports non-zero speed while running."""
         try:
-            target_velocity = 6000
-            motor.set_velocity(velocity_erpm=target_velocity)
+            motor.set_velocity(velocity_erpm=6000)
             time.sleep(0.5)
 
-            status = get_status_with_retry(motor)
-            assert status is not None
-            assert len(status) > 0
-
-            motor.status_parser.payload_offset = 0
-            motor.status_parser.parse_temperatures(status)
-            motor.status_parser.parse_currents(status)
-            duty_speed_voltage = motor.status_parser.parse_duty_speed_voltage(status)
-            assert duty_speed_voltage is not None
-            # Verify motor is moving (speed should be non-zero and in reasonable range)
-            if abs(duty_speed_voltage.speed_erpm) < 1000000:
-                assert abs(duty_speed_voltage.speed_erpm) > 1000, (
-                    f"Motor not moving (speed: {duty_speed_voltage.speed_erpm} ERPM)"
-                )
+            speed = parse_speed_from_status(motor, get_status_with_retry(motor))
+            if speed is not None:
+                assert abs(speed) > 1000, f"Motor not moving ({speed} ERPM)"
         finally:
             motor.set_velocity(velocity_erpm=0)
             time.sleep(0.3)
 
     @pytest.mark.flaky(reruns=3, reruns_delay=1)
-    @pytest.mark.parametrize("target_velocity", [5000, 10000, 15000])
-    def test_velocity_command_sequence(
-        self, motor: CubeMarsAK606v3, target_velocity: int
-    ) -> None:
-        """Test motor accepts various velocity commands."""
-        # Start from zero
-        motor.set_position(position_degrees=0.0)
+    @pytest.mark.parametrize("target", [5000, 10000, 15000])
+    def test_multiple_velocities(self, motor: CubeMarsAK606v3, target: int) -> None:
+        """Motor reaches various target velocities within 30% tolerance."""
+        motor.set_velocity(velocity_erpm=target)
         time.sleep(0.5)
 
-        # Set target velocity and verify motor reaches it
-        motor.set_velocity(velocity_erpm=target_velocity)
-        time.sleep(0.5)  # Give motor time to reach velocity
-
-        # Verify motor is moving at commanded velocity
-        status = get_status_with_retry(motor)
-        assert status is not None
-        assert len(status) > 0
-
-        motor.status_parser.payload_offset = 0
-        motor.status_parser.parse_temperatures(status)
-        motor.status_parser.parse_currents(status)
-        duty_speed_voltage = motor.status_parser.parse_duty_speed_voltage(status)
-        assert duty_speed_voltage is not None
-        # Verify motor is moving at target velocity (allow ±30% tolerance)
-        if abs(duty_speed_voltage.speed_erpm) < 1000000:
-            velocity_error = abs(duty_speed_voltage.speed_erpm - target_velocity)
-            assert velocity_error < target_velocity * 0.3, (
-                f"Velocity {duty_speed_voltage.speed_erpm} not close to target {target_velocity} ERPM"
+        speed = parse_speed_from_status(motor, get_status_with_retry(motor))
+        if speed is not None:
+            assert abs(speed - target) < target * 0.3, (
+                f"Speed {speed} ERPM not within 30% of target {target} ERPM"
             )
 
-        # Stop
         motor.set_velocity(velocity_erpm=0)
         time.sleep(0.3)
+
+
+# -- Safety --
+
+
+class TestExosuitSafety:
+    """Test velocity safety thresholds and tendon control."""
+
+    @pytest.mark.flaky(reruns=3, reruns_delay=1)
+    def test_low_velocity_blocked(self, motor: CubeMarsAK606v3) -> None:
+        """Velocities below 5000 ERPM raise ValueError by default."""
+        with pytest.raises(ValueError, match="below safe threshold"):
+            motor.set_velocity(velocity_erpm=100)
+
+    @pytest.mark.flaky(reruns=3, reruns_delay=1)
+    def test_low_velocity_allowed_with_flag(self, motor: CubeMarsAK606v3) -> None:
+        """Low velocity permitted when explicitly bypassed (no actual send)."""
+        # Only verify the flag doesn't raise - don't actually send to motor
+        # because low speeds cause oscillations/noise with firmware accel settings
+        try:
+            motor.set_velocity(velocity_erpm=100, allow_low_speed=True)
+        finally:
+            motor.stop()
+
+    @pytest.mark.flaky(reruns=3, reruns_delay=1)
+    def test_tendon_pull_release_stop(self, motor: CubeMarsAK606v3) -> None:
+        """Tendon control: pull, release, stop all work."""
+        motor.control_exosuit_tendon(action="pull", velocity_erpm=8000)
+        time.sleep(0.3)
+
+        motor.control_exosuit_tendon(action="release", velocity_erpm=6000)
+        time.sleep(0.3)
+
+        motor.control_exosuit_tendon(action="stop")
+        time.sleep(0.2)
+
+        assert motor.get_status() is not None
+
+    @pytest.mark.flaky(reruns=3, reruns_delay=1)
+    def test_tendon_invalid_action(self, motor: CubeMarsAK606v3) -> None:
+        """Invalid tendon action raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid action"):
+            motor.control_exosuit_tendon(action="invalid")


### PR DESCRIPTION
# Summary
Describe the main changes in this PR:

Noise Elimination
- Soft-start: Pre-spin with 3A current for 150ms before velocity command to bypass noisy 0-5000 ERPM zone
- Clean stop: stop() now uses current=0 (CMD_SET_CURRENT 0x47) instead of velocity PID deceleration, releases windings immediately
- Unified stopping: set_velocity(0) internally calls stop() to prevent accidental noise
